### PR TITLE
Fix admin tabs review issues #28 (1-3)

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -221,11 +221,12 @@ export async function listAllSubscribers(db: D1Database): Promise<SubscriberWith
 }
 
 export async function countSubscribers(db: D1Database): Promise<{ total: number; confirmed: number; pending: number; bounced: number }> {
+    // Buckets are mutually exclusive: a row counts in exactly one of confirmed/pending/bounced.
     const row = await db.prepare(
         `SELECT
             COUNT(*) AS total,
-            SUM(CASE WHEN confirmed_at IS NOT NULL AND status = 'active' THEN 1 ELSE 0 END) AS confirmed,
-            SUM(CASE WHEN confirmed_at IS NULL THEN 1 ELSE 0 END) AS pending,
+            SUM(CASE WHEN status = 'active' AND confirmed_at IS NOT NULL THEN 1 ELSE 0 END) AS confirmed,
+            SUM(CASE WHEN status = 'active' AND confirmed_at IS NULL THEN 1 ELSE 0 END) AS pending,
             SUM(CASE WHEN status IN ('bounced', 'complained') THEN 1 ELSE 0 END) AS bounced
          FROM subscribers`
     ).first<{ total: number; confirmed: number; pending: number; bounced: number }>();

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -101,12 +101,16 @@ async function requireAdmin(c: import("hono").Context<HonoEnv>): Promise<Respons
 // ============================================================================
 
 // ============================================================================
-// GET / - Admin Dashboard
-// ============================================================================
-
-// ============================================================================
 // GET / - Admin Dashboard (tabbed: dashboard | episodes | subscribers | activity | maintenance)
 // ============================================================================
+
+function renderTabError(activeTab: string, err: unknown): string {
+    const message = err instanceof Error ? err.message : String(err);
+    return `<div class="alert alert-error" style="margin-top: 1rem;">
+        <strong>Failed to load ${escapeHtml(activeTab)} tab.</strong><br>
+        ${escapeHtml(message)}
+    </div>`;
+}
 
 admin.get("/", async (c) => {
     const authError = await requireAdmin(c);
@@ -118,60 +122,69 @@ admin.get("/", async (c) => {
     type Tab = typeof validTabs[number];
     const activeTab: Tab = (validTabs as readonly string[]).includes(tabParam) ? (tabParam as Tab) : "dashboard";
 
+    const MAX_PAGE = 10000;
+    const pageRaw = parseInt(c.req.query("page") || "1", 10) || 1;
+    const page = Math.min(MAX_PAGE, Math.max(1, pageRaw));
+
     let title = "Admin";
     let body = "";
 
-    if (activeTab === "dashboard") {
-        const [podcasts, activityLog, activeJobs, episodeCount] = await Promise.all([
-            getPodcastList(c.env.TLDL_DATA),
-            getActivityLog(c.env.TLDL_DATA, 8),
-            listActiveJobsWithDO(c.env, c.env.TLDL_DATA),
-            listEpisodes(c.env.TLDL_DATA, { page: 1, pageSize: 1 }),
-        ]);
-        const monitoredPodcasts = await listMonitoredPodcasts(c.env.TLDL_DATA);
-        const errorCount = monitoredPodcasts.filter(p => p.status === "error").length;
-        const lastChecked = monitoredPodcasts.reduce((latest, p) => {
-            if (!p.lastChecked) return latest;
-            return !latest || p.lastChecked > latest ? p.lastChecked : latest;
-        }, "" as string);
-        title = "Dashboard";
-        body = renderDashboardTab({
-            totalEpisodes: episodeCount.total,
-            totalPodcasts: podcasts.length,
-            errorCount,
-            lastChecked,
-            activeJobsCount: activeJobs.length,
-            activityLog,
-        });
-    } else if (activeTab === "episodes") {
-        const page = Math.max(1, parseInt(c.req.query("page") || "1", 10) || 1);
-        const pageSize = 10;
-        const result = await listEpisodes(c.env.TLDL_DATA, { page, pageSize });
-        const episodes = await Promise.all(
-            result.episodes.map(async (episode) => {
-                const summaries = await listSummariesForEpisode(c.env.TLDL_DATA, episode.id);
-                const templateBadges = summaries
-                    .map((s) => `<span class="badge">${escapeHtml(s.templateId)}</span>`)
-                    .join("");
-                return { ...episode, templateBadges };
-            })
-        );
-        title = "Episodes";
-        body = renderEpisodesTab({ episodes, page, totalPages: result.totalPages });
-    } else if (activeTab === "subscribers") {
-        const [subscribers, counts] = await Promise.all([
-            listAllSubscribers(c.env.DB),
-            countSubscribers(c.env.DB),
-        ]);
-        title = "Subscribers";
-        body = renderSubscribersTab({ subscribers, counts });
-    } else if (activeTab === "activity") {
-        const activityLog = await getActivityLog(c.env.TLDL_DATA);
-        title = "Activity";
-        body = renderActivityTab(activityLog);
-    } else {
-        title = "Maintenance";
-        body = renderMaintenanceTab();
+    try {
+        if (activeTab === "dashboard") {
+            const [podcasts, activityLog, activeJobs, episodeCount, monitoredPodcasts] = await Promise.all([
+                getPodcastList(c.env.TLDL_DATA),
+                getActivityLog(c.env.TLDL_DATA, 8),
+                listActiveJobsWithDO(c.env, c.env.TLDL_DATA),
+                listEpisodes(c.env.TLDL_DATA, { page: 1, pageSize: 1 }),
+                listMonitoredPodcasts(c.env.TLDL_DATA),
+            ]);
+            const errorCount = monitoredPodcasts.filter(p => p.status === "error").length;
+            const lastChecked = monitoredPodcasts.reduce((latest, p) => {
+                if (!p.lastChecked) return latest;
+                return !latest || p.lastChecked > latest ? p.lastChecked : latest;
+            }, "" as string);
+            title = "Dashboard";
+            body = renderDashboardTab({
+                totalEpisodes: episodeCount.total,
+                totalPodcasts: podcasts.length,
+                errorCount,
+                lastChecked,
+                activeJobsCount: activeJobs.length,
+                activityLog,
+            });
+        } else if (activeTab === "episodes") {
+            const pageSize = 10;
+            const result = await listEpisodes(c.env.TLDL_DATA, { page, pageSize });
+            const episodes = await Promise.all(
+                result.episodes.map(async (episode) => {
+                    const summaries = await listSummariesForEpisode(c.env.TLDL_DATA, episode.id);
+                    const templateBadges = summaries
+                        .map((s) => `<span class="badge">${escapeHtml(s.templateId)}</span>`)
+                        .join("");
+                    return { ...episode, templateBadges };
+                })
+            );
+            title = "Episodes";
+            body = renderEpisodesTab({ episodes, page, totalPages: result.totalPages });
+        } else if (activeTab === "subscribers") {
+            const [subscribers, counts] = await Promise.all([
+                listAllSubscribers(c.env.DB),
+                countSubscribers(c.env.DB),
+            ]);
+            title = "Subscribers";
+            body = renderSubscribersTab({ subscribers, counts });
+        } else if (activeTab === "activity") {
+            const activityLog = await getActivityLog(c.env.TLDL_DATA);
+            title = "Activity";
+            body = renderActivityTab(activityLog);
+        } else {
+            title = "Maintenance";
+            body = renderMaintenanceTab();
+        }
+    } catch (err) {
+        console.error(`admin tab "${activeTab}" failed:`, err);
+        title = "Admin";
+        body = renderTabError(activeTab, err);
     }
 
     return c.html(AdminLayout({
@@ -1710,35 +1723,6 @@ admin.get("/podcasts", async (c) => {
                 btn.disabled = false;
                 btn.textContent = 'Add Podcast';
             });
-
-            async function checkAllNow() {
-                const msg = document.getElementById('settings-message');
-                msg.className = 'alert alert-info';
-                msg.textContent = 'Checking all podcasts...';
-                msg.style.display = 'block';
-                
-                try {
-                    const response = await fetch('/admin/podcasts/check-now', {
-                        method: 'POST',
-                        credentials: 'include',
-                    });
-                    
-                    const data = await response.json();
-                    msg.className = response.ok ? 'alert alert-success' : 'alert alert-error';
-                    msg.textContent = response.ok 
-                        ? 'Checked ' + data.checked + ' podcasts. ' + data.totalNewEpisodes + ' new episode(s) queued.'
-                        : (data.error || 'Failed');
-                    msg.style.display = 'block';
-                    
-                    if (response.ok && data.totalNewEpisodes > 0) {
-                        setTimeout(() => window.location.reload(), 2000);
-                    }
-                } catch (err) {
-                    msg.className = 'alert alert-error';
-                    msg.textContent = 'Failed to check podcasts';
-                    msg.style.display = 'block';
-                }
-            }
 
             async function checkPodcast(podcastId) {
                 const card = document.getElementById('podcast-' + podcastId);


### PR DESCRIPTION
Closes the high+medium findings from the post-merge code review of #admin-tabs-redesign. See [issue #28](https://github.com/rianvdm/tldl/issues/28).

## Changes

### 1. [HIGH] Remove duplicate `checkAllNow()` on /admin/podcasts
The /admin/podcasts page renders through `AdminLayout`, which already injects the shared `checkAllNow` from `HEADER_SCRIPT`. The inline override wrote to `#settings-message` while the layout version writes to `#check-all-status`. Either could win depending on hoisting order, and any future edit to `HEADER_SCRIPT` would silently fail on /podcasts only. Inline copy deleted; the existing button now uses the shared handler.

### 2. [HIGH] Wrap tab dispatcher in try/catch
A missing `DB` binding or a D1 outage on the Subscribers tab used to 500 the entire admin page (chrome and all). Each tab branch now runs inside a single try/catch; on failure we render an in-tab error card so the header + tab nav remain usable and the user can pivot to a working tab. Errors are logged via `console.error`.

### 3. [MEDIUM] Fix subscriber count buckets
`countSubscribers` now scopes the `pending` bucket to `status = 'active' AND confirmed_at IS NULL` instead of `confirmed_at IS NULL` regardless of status. The three buckets (`confirmed`/`pending`/`bounced`) are now mutually exclusive and consistent with how the row renderer classifies rows in `tabs.ts:414-418`.

## Drive-by cleanup
- Added upper bound of 10000 on the `page` query param (was unbounded — `?page=999999999` was forwarded to `listEpisodes` unmodified).
- Consolidated duplicate comment header in `admin.ts`.
- Folded the standalone `listMonitoredPodcasts` await on the dashboard tab into the main `Promise.all` (one fewer round-trip).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/admin.test.ts test/integration/full-flow.test.ts` — 76/76 pass
- [ ] Smoke-test in prod after merge: visit `/admin?tab=subscribers`, confirm counts add up; click "Check All Now" from the /admin/podcasts page and verify status appears in the global header banner

## Base
Targets `admin-tabs-redesign` so the diff stays scoped to the fixes. Once that branch lands on `main`, this can fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)