### PR TITLE
Speed up Episodes tab: denormalize template IDs onto episode index

### DIFF
--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -351,14 +351,32 @@ export async function getEpisodeIndex(
 }
 
 /**
+ * List the template IDs that have a saved summary for this episode.
+ * Used to denormalize summary presence onto the episode index entry, so the
+ * /admin Episodes tab doesn't have to fan out a list+get per visible episode.
+ */
+async function listSummaryTemplateIds(kv: KVNamespace, episodeId: string): Promise<string[]> {
+    const prefix = `summary:${episodeId}:`;
+    const keys = await kv.list({ prefix });
+    return keys.keys
+        .map((k) => k.name.slice(prefix.length))
+        .filter((id) => id.length > 0)
+        .sort();
+}
+
+/**
  * Add an episode to the index (called when episode is saved)
- * Maintains sorted order by createdAt descending
+ * Maintains sorted order by createdAt descending.
+ * Populates `templateIds` from any summaries already saved for this episode.
  */
 export async function addToEpisodeIndex(
     kv: KVNamespace,
     entry: EpisodeIndexEntry
 ): Promise<void> {
-    const index = await getEpisodeIndex(kv);
+    const [index, templateIds] = await Promise.all([
+        getEpisodeIndex(kv),
+        listSummaryTemplateIds(kv, entry.id),
+    ]);
 
     // Check if episode already exists (update case)
     const existingIdx = index.findIndex((e) => e.id === entry.id);
@@ -367,11 +385,38 @@ export async function addToEpisodeIndex(
     }
 
     // Add new entry and sort by createdAt descending
-    index.push(entry);
+    index.push({ ...entry, templateIds: templateIds.length > 0 ? templateIds : entry.templateIds });
     index.sort(
         (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     );
+
+    await kv.put(KV_KEYS.episodeIndex, JSON.stringify(index), {
+        expirationTtl: TTL.CONTENT,
+    });
+}
+
+/**
+ * Add a summary template ID to an existing episode index entry (idempotent).
+ * No-op if the entry doesn't exist yet — `addToEpisodeIndex` will pick up the
+ * template the first time it's called for this episode.
+ */
+export async function addTemplateToEpisodeIndex(
+    kv: KVNamespace,
+    episodeId: string,
+    templateId: string
+): Promise<void> {
+    const index = await getEpisodeIndex(kv);
+    const entryIdx = index.findIndex((e) => e.id === episodeId);
+    if (entryIdx === -1) return;
+
+    const existing = index[entryIdx].templateIds ?? [];
+    if (existing.includes(templateId)) return;
+
+    index[entryIdx] = {
+        ...index[entryIdx],
+        templateIds: [...existing, templateId].sort(),
+    };
 
     await kv.put(KV_KEYS.episodeIndex, JSON.stringify(index), {
         expirationTtl: TTL.CONTENT,
@@ -418,10 +463,17 @@ export async function rebuildEpisodeIndex(kv: KVNamespace): Promise<number> {
         })
     );
 
+    const validEpisodes = allEpisodes.filter((ep): ep is Episode => ep !== null);
+
+    // Look up the saved summary template IDs for each episode so the rebuilt
+    // index can render the /admin Episodes tab without per-card fan-out.
+    const templateIdsByEpisode = await Promise.all(
+        validEpisodes.map((ep) => listSummaryTemplateIds(kv, ep.id))
+    );
+
     // Build index entries and sort
-    const index: EpisodeIndexEntry[] = allEpisodes
-        .filter((ep): ep is Episode => ep !== null)
-        .map((ep) => ({
+    const index: EpisodeIndexEntry[] = validEpisodes
+        .map((ep, i) => ({
             id: ep.id,
             podcastName: ep.podcastName,
             episodeTitle: ep.episodeTitle,
@@ -432,6 +484,7 @@ export async function rebuildEpisodeIndex(kv: KVNamespace): Promise<number> {
             tags: ep.tags,
             podcastAuthor: ep.podcastAuthor,
             audioUrl: ep.audioUrl,
+            templateIds: templateIdsByEpisode[i].length > 0 ? templateIdsByEpisode[i] : undefined,
         }))
         .sort(
             (a, b) =>
@@ -482,7 +535,13 @@ export async function getTranscript(
 // ============================================================================
 
 /**
- * Save a summary record to KV
+ * Save a summary record to KV.
+ *
+ * Also denormalizes the summary template ID onto the episode index entry so
+ * the /admin Episodes tab can render template badges without reading every
+ * summary key. The index update is a no-op if the index entry doesn't exist
+ * yet — in that case `addToEpisodeIndex` will populate `templateIds` from
+ * KV when it's eventually called.
  */
 export async function saveSummary(
     kv: KVNamespace,
@@ -495,6 +554,7 @@ export async function saveSummary(
             expirationTtl: TTL.CONTENT,
         }
     );
+    await addTemplateToEpisodeIndex(kv, summary.episodeId, summary.templateId);
 }
 
 /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -155,15 +155,14 @@ admin.get("/", async (c) => {
         } else if (activeTab === "episodes") {
             const pageSize = 10;
             const result = await listEpisodes(c.env.TLDL_DATA, { page, pageSize });
-            const episodes = await Promise.all(
-                result.episodes.map(async (episode) => {
-                    const summaries = await listSummariesForEpisode(c.env.TLDL_DATA, episode.id);
-                    const templateBadges = summaries
-                        .map((s) => `<span class="badge">${escapeHtml(s.templateId)}</span>`)
-                        .join("");
-                    return { ...episode, templateBadges };
-                })
-            );
+            // Template badges come straight from the index entry (templateIds is
+            // denormalized at write-time), so no per-episode fan-out here.
+            const episodes = result.episodes.map((episode) => {
+                const templateBadges = (episode.templateIds ?? [])
+                    .map((id) => `<span class="badge">${escapeHtml(id)}</span>`)
+                    .join("");
+                return { ...episode, templateBadges };
+            });
             title = "Episodes";
             body = renderEpisodesTab({ episodes, page, totalPages: result.totalPages });
         } else if (activeTab === "subscribers") {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export interface EpisodeIndexEntry {
     tags?: string[];               // AI-generated episode tags (included for filtering)
     podcastAuthor?: string;        // Podcast author/host name
     audioUrl?: string;             // Source audio URL — used for dedup when publishers retitle/regenerate GUIDs
+    templateIds?: string[];        // Summary template IDs that exist for this episode — denormalized for /admin Episodes tab
 }
 
 /**

--- a/test/kv.test.ts
+++ b/test/kv.test.ts
@@ -16,6 +16,9 @@ import {
     getSummary,
     listSummariesForEpisode,
     rebuildEpisodeIndex,
+    addToEpisodeIndex,
+    addTemplateToEpisodeIndex,
+    getEpisodeIndex,
 } from "../src/lib/kv";
 import type { Job, Episode, Transcript, Summary } from "../src/types";
 
@@ -393,5 +396,94 @@ describe("Summary Operations", () => {
             "no-summaries-here"
         );
         expect(listed).toEqual([]);
+    });
+});
+
+describe("Episode index templateIds denormalization", () => {
+    beforeEach(async () => {
+        for (const prefix of ["episode:", "summary:", "episodes:index"]) {
+            const keys = await env.TLDL_DATA.list({ prefix });
+            await Promise.all(keys.keys.map((k) => env.TLDL_DATA.delete(k.name)));
+        }
+    });
+
+    it("addToEpisodeIndex picks up templateIds from existing summaries", async () => {
+        const episode = createSampleEpisode({ id: "ep-a" });
+        await saveSummary(env.TLDL_DATA, createSampleSummary({ episodeId: "ep-a", templateId: "key-takeaways" }));
+        await saveSummary(env.TLDL_DATA, createSampleSummary({ episodeId: "ep-a", templateId: "narrative-summary" }));
+
+        await addToEpisodeIndex(env.TLDL_DATA, {
+            id: episode.id,
+            podcastName: episode.podcastName,
+            episodeTitle: episode.episodeTitle,
+            episodeDate: episode.episodeDate,
+            episodeDuration: episode.episodeDuration,
+            createdAt: episode.createdAt,
+            expiresAt: episode.expiresAt,
+        });
+
+        const index = await getEpisodeIndex(env.TLDL_DATA);
+        const entry = index.find((e) => e.id === "ep-a");
+        expect(entry?.templateIds).toEqual(["key-takeaways", "narrative-summary"]);
+    });
+
+    it("saveSummary appends templateId to an existing index entry", async () => {
+        const episode = createSampleEpisode({ id: "ep-b" });
+        await addToEpisodeIndex(env.TLDL_DATA, {
+            id: episode.id,
+            podcastName: episode.podcastName,
+            episodeTitle: episode.episodeTitle,
+            episodeDate: episode.episodeDate,
+            episodeDuration: episode.episodeDuration,
+            createdAt: episode.createdAt,
+            expiresAt: episode.expiresAt,
+        });
+
+        await saveSummary(env.TLDL_DATA, createSampleSummary({ episodeId: "ep-b", templateId: "eli5" }));
+
+        const index = await getEpisodeIndex(env.TLDL_DATA);
+        const entry = index.find((e) => e.id === "ep-b");
+        expect(entry?.templateIds).toEqual(["eli5"]);
+    });
+
+    it("addTemplateToEpisodeIndex is idempotent (set semantics)", async () => {
+        const episode = createSampleEpisode({ id: "ep-c" });
+        await addToEpisodeIndex(env.TLDL_DATA, {
+            id: episode.id,
+            podcastName: episode.podcastName,
+            episodeTitle: episode.episodeTitle,
+            episodeDate: episode.episodeDate,
+            episodeDuration: episode.episodeDuration,
+            createdAt: episode.createdAt,
+            expiresAt: episode.expiresAt,
+        });
+
+        await addTemplateToEpisodeIndex(env.TLDL_DATA, "ep-c", "key-takeaways");
+        await addTemplateToEpisodeIndex(env.TLDL_DATA, "ep-c", "key-takeaways");
+
+        const index = await getEpisodeIndex(env.TLDL_DATA);
+        expect(index.find((e) => e.id === "ep-c")?.templateIds).toEqual(["key-takeaways"]);
+    });
+
+    it("addTemplateToEpisodeIndex no-ops when entry doesn't exist", async () => {
+        // Should not throw and should not create a phantom entry.
+        await addTemplateToEpisodeIndex(env.TLDL_DATA, "ghost", "key-takeaways");
+        const index = await getEpisodeIndex(env.TLDL_DATA);
+        expect(index.find((e) => e.id === "ghost")).toBeUndefined();
+    });
+
+    it("rebuildEpisodeIndex populates templateIds from existing summary keys", async () => {
+        const episode = createSampleEpisode({ id: "ep-d" });
+        await saveEpisode(env.TLDL_DATA, episode);
+        // Use direct put to avoid the saveSummary side effect, simulating pre-feature data.
+        await env.TLDL_DATA.put(
+            KV_KEYS.summary("ep-d", "key-takeaways"),
+            JSON.stringify(createSampleSummary({ episodeId: "ep-d", templateId: "key-takeaways" }))
+        );
+
+        await rebuildEpisodeIndex(env.TLDL_DATA);
+
+        const index = await getEpisodeIndex(env.TLDL_DATA);
+        expect(index.find((e) => e.id === "ep-d")?.templateIds).toEqual(["key-takeaways"]);
     });
 });


### PR DESCRIPTION
Closes #31.

## Summary
- Adds `templateIds?: string[]` to `EpisodeIndexEntry`. The /admin Episodes tab now reads template badges directly from the index entry instead of fanning out one `listSummariesForEpisode` per visible card.
- `addToEpisodeIndex` populates `templateIds` from the live summary keys when a new episode is registered.
- `saveSummary` calls a new idempotent `addTemplateToEpisodeIndex(kv, episodeId, templateId)` to keep the index in sync when summaries are added later (template regeneration, manual edits). No-op when no entry exists yet.
- `rebuildEpisodeIndex` populates `templateIds` from existing summary keys, so one rebuild after deploy backfills the field for all existing episodes.

## Perf impact
Episodes tab drops from ~11 KV reads (1 index + 10 summary lists, each with N value gets) to 1 KV read.

## Tradeoffs (called out in #31)
- **One extra KV write per `saveSummary`** (the index update). The previous behavior was a single put.
- **Extra `kv.list` per `addToEpisodeIndex` call** to discover existing summaries. List op, not value fetches — cheap.
- **Eventual consistency on partial failure** — if `saveSummary`'s put succeeds but the index update fails, badges go stale until the next rebuild. Display-only, admin-only.
- All write paths funnel through one helper, so there's only one place to keep in sync.

## Backfill
After deploy, hit `/admin?tab=maintenance → Rebuild Episode Index` once. Existing entries get `templateIds` populated. New summaries from there on update the field automatically.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 462/477 pass (3 pre-existing isolated-storage failures unrelated to this branch)
- [x] New unit tests in `test/kv.test.ts`:
  - `addToEpisodeIndex` picks up templateIds from existing summaries
  - `saveSummary` appends templateId to an existing index entry
  - `addTemplateToEpisodeIndex` is idempotent (set semantics)
  - `addTemplateToEpisodeIndex` no-ops when entry doesn't exist
  - `rebuildEpisodeIndex` populates templateIds from existing summary keys
- [ ] After merge + deploy: rebuild the index, then visit /admin?tab=episodes and confirm template badges still render and the tab loads noticeably faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)