### PR TITLE
Tolerate trailing-chunk transcription failures (#27)

### DIFF
--- a/src/queue/consumer.ts
+++ b/src/queue/consumer.ts
@@ -463,6 +463,15 @@ async function processEpisode(ctx: ProcessingContext): Promise<void> {
             { apiKey: env.OPENAI_API_KEY, skipValidation },
         );
 
+        if (transcriptionResult.partial) {
+            console.warn(JSON.stringify({
+                event: "transcription_partial",
+                episodeId,
+                reason: transcriptionResult.partialReason,
+                textLength: transcriptionResult.text.length,
+            }));
+        }
+
         transcriptSource = transcriptionResult.source;
         transcript = {
             episodeId,

--- a/src/services/transcription.ts
+++ b/src/services/transcription.ts
@@ -189,6 +189,10 @@ export interface TranscriptionResult {
     text: string;
     source: "openai";
     model: string;
+    /** True when the final chunk failed transcription but earlier chunks succeeded. */
+    partial?: boolean;
+    /** Human-readable reason when partial=true. */
+    partialReason?: string;
 }
 
 export interface AudioValidation {
@@ -556,6 +560,7 @@ async function callWhisperApi(
         const isCorruptedError = errorText.includes("corrupted or unsupported");
         const isInputTooLarge = errorText.includes("input_too_large") || errorText.includes("too large for this model");
         const isGpt4oModel = provider.model === "gpt-4o-mini-transcribe";
+        let fallbackErrorMessage: string | null = null;
         if (status === 400 && (isCorruptedError || isInputTooLarge) && isGpt4oModel) {
             const reason = isInputTooLarge
                 ? "gpt-4o-mini-transcribe chunk too large, falling back to whisper-1"
@@ -638,19 +643,23 @@ async function callWhisperApi(
                 );
                 return { text: fallbackText, model: "whisper-1" };
             } catch (fallbackErr) {
+                fallbackErrorMessage = fallbackErr instanceof Error ? fallbackErr.message : "Unknown";
                 console.error(
                     JSON.stringify({
                         event: "whisper_fallback_error",
                         fallbackModel: "whisper-1",
-                        error: fallbackErr instanceof Error ? fallbackErr.message : "Unknown",
+                        error: fallbackErrorMessage,
                     })
                 );
             }
         }
 
+        const errorDetail = fallbackErrorMessage
+            ? `${provider.name} Whisper API error: ${errorText} | whisper-1 fallback also failed: ${fallbackErrorMessage}`
+            : `${provider.name} Whisper API error: ${errorText}`;
         throw new AppError(
             ERROR_CODES.TRANSCRIPTION_FAILED,
-            `${provider.name} Whisper API error: ${errorText}`,
+            errorDetail,
         );
     }
 
@@ -886,6 +895,7 @@ async function transcribeWithChunking(
     // Process chunks sequentially to manage memory
     const transcriptions: ChunkTranscription[] = [];
     let usedFallbackModel: string | null = null;
+    let tailChunkSkipped: { chunkIndex: number; error: string } | null = null;
 
     for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
@@ -970,15 +980,38 @@ async function transcribeWithChunking(
                 })
             );
         } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : "Unknown error";
+
             // Log the error with context
             console.error(
                 JSON.stringify({
                     event: "chunk_failed",
                     chunkIndex: i + 1,
                     totalChunks,
-                    error: error instanceof Error ? error.message : "Unknown error",
+                    error: errorMessage,
                 })
             );
+
+            // Tolerate failure of the trailing chunk: if every prior chunk succeeded,
+            // accept a partial transcript rather than failing the whole episode.
+            // The tail chunk is typically only a few minutes of audio (often outro/credits)
+            // and certain podcast files have non-decodable trailers (ID3v1 footers,
+            // ad markers, etc.) that both gpt-4o-mini-transcribe and whisper-1 reject.
+            const isLastChunk = i === chunks.length - 1;
+            if (isLastChunk && transcriptions.length > 0 && totalChunks > 1) {
+                tailChunkSkipped = { chunkIndex: i + 1, error: errorMessage };
+                console.warn(
+                    JSON.stringify({
+                        event: "tail_chunk_skipped",
+                        chunkIndex: i + 1,
+                        totalChunks,
+                        successfulChunks: transcriptions.length,
+                        chunkSizeBytes: chunk.endByte - chunk.startByte + 1,
+                        error: errorMessage,
+                    })
+                );
+                break;
+            }
 
             // Re-throw with context
             if (error instanceof AppError) {
@@ -986,7 +1019,7 @@ async function transcribeWithChunking(
             }
             throw new AppError(
                 ERROR_CODES.TRANSCRIPTION_FAILED,
-                `Failed to transcribe chunk ${i + 1}/${totalChunks}: ${error instanceof Error ? error.message : "Unknown error"}`,
+                `Failed to transcribe chunk ${i + 1}/${totalChunks}: ${errorMessage}`,
                 error instanceof Error ? error : undefined
             );
         }
@@ -1007,6 +1040,10 @@ async function transcribeWithChunking(
         text: combinedText,
         source: provider.name,
         model: usedFallbackModel || provider.model,
+        ...(tailChunkSkipped && {
+            partial: true,
+            partialReason: `Final chunk ${tailChunkSkipped.chunkIndex}/${totalChunks} failed transcription after both gpt-4o-mini-transcribe and whisper-1 rejected it (${tailChunkSkipped.error}). The transcript is missing the audio from the last chunk.`,
+        }),
     };
 }
 

--- a/test/transcription.test.ts
+++ b/test/transcription.test.ts
@@ -210,6 +210,51 @@ describe("transcribeAudio", () => {
         expect(result.text).toContain("second part");
     });
 
+    it("should return partial transcript when only the trailing chunk fails", async () => {
+        // 30MB → 3 chunks. Chunks 1+2 succeed; chunk 3 fails on gpt-4o-mini AND whisper-1 fallback.
+        // Expect: no throw, result.partial === true, result.text contains the first two chunks.
+        const largeSize = 30 * 1024 * 1024;
+        const mockChunkBuffer = new ArrayBuffer(15 * 1024 * 1024);
+        const corruptedError = JSON.stringify({
+            error: { message: "Audio file might be corrupted or unsupported", type: "invalid_request_error", param: "file", code: "invalid_value" },
+        });
+        const whisper1Error = JSON.stringify({
+            error: { message: "The audio file could not be decoded or its format is not supported.", type: "invalid_request_error", param: null, code: null },
+        });
+
+        vi.spyOn(globalThis, "fetch")
+            // HEAD validation
+            .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": String(largeSize), "content-type": "audio/mpeg" } }))
+            // redirect resolution
+            .mockResolvedValueOnce(new Response(null, { status: 200 }))
+            // header fetch (512B)
+            .mockResolvedValueOnce(new Response(new ArrayBuffer(512), { status: 206 }))
+            // chunk 1 fetch + transcribe (success)
+            .mockResolvedValueOnce(new Response(mockChunkBuffer, { status: 206 }))
+            .mockResolvedValueOnce(new Response("First chunk transcript.", { status: 200 }))
+            // chunk 2 fetch + transcribe (success)
+            .mockResolvedValueOnce(new Response(mockChunkBuffer, { status: 206 }))
+            .mockResolvedValueOnce(new Response("Second chunk transcript.", { status: 200 }))
+            // chunk 3 (tail) fetch — succeeds at the byte level
+            .mockResolvedValueOnce(new Response(new ArrayBuffer(1024 * 1024), { status: 206 }))
+            // chunk 3 gpt-4o-mini-transcribe → 400 corrupted (triggers fallback)
+            .mockResolvedValueOnce(new Response(corruptedError, { status: 400 }))
+            // chunk 3 whisper-1 fallback → 400 also (no retry on non-transient)
+            .mockResolvedValueOnce(new Response(whisper1Error, { status: 400 }));
+
+        const result = await transcribeAudio(
+            "https://example.com/large.mp3",
+            "test-api-key"
+        );
+
+        expect(result.source).toBe("openai");
+        expect(result.partial).toBe(true);
+        expect(result.partialReason).toContain("Final chunk 3/3");
+        expect(result.partialReason).toContain("whisper-1");
+        expect(result.text).toContain("First chunk");
+        expect(result.text).toContain("Second chunk");
+    });
+
     it("should throw TRANSCRIPTION_FAILED on Whisper API error", async () => {
         const mockAudioBuffer = new ArrayBuffer(1024);
 


### PR DESCRIPTION
## Summary
- When chunked transcription succeeds for every chunk except the last and both `gpt-4o-mini-transcribe` and `whisper-1` reject the tail chunk, return the partial transcript instead of failing the entire episode.
- Surface the `whisper-1` fallback error in the final `AppError` so failure messages reflect both attempts (was previously masked).
- New `partial?: boolean` + `partialReason?: string` on `TranscriptionResult`; consumer logs a `transcription_partial` warning when set.

## Why
Closes #27. Worker observability logs for the failed Pragmatic Engineer episode (`1769051199_1000764502093`, request `Q3NBQKXUOE84S31Y` at 2026-04-29 22:03–22:07 UTC) show:

- File is MP3 (`id3_tag_parsed` fires per chunk — invalidates the M4A theory in my earlier comment).
- Chunks 1–6 of 7 transcribed cleanly with `gpt-4o-mini-transcribe`.
- Chunk 7 (the 5.9 MB tail of a 96 MB file, range `bytes=94175232-100316616`) was rejected by both models — `gpt-4o-mini-transcribe` returned the canonical "Audio file might be corrupted or unsupported"; the `whisper-1` fallback returned "The audio file could not be decoded or its format is not supported."

Tail chunks often contain non-decodable trailers (ID3v1 footers, podcast host markers, ad insertions) or land at byte offsets where the 512-byte prepended header isn't enough resync context. Failing the whole episode for a few minutes of outro audio is the wrong tradeoff.

## Behavior

- Triggered only when `i === chunks.length - 1` AND `transcriptions.length > 0` AND `totalChunks > 1`. Single-chunk total failures and earlier-chunk failures still throw as before.
- Emits a `tail_chunk_skipped` warning event with chunk size and successful-chunk count.
- The transcript is saved + summarized normally; consumer logs a `transcription_partial` event for visibility.

## Test plan
- [x] `npx vitest run test/transcription.test.ts` — 42/42 pass, including new `should return partial transcript when only the trailing chunk fails`
- [x] `npm test` — 463/478 pass; the 15 failing tests are the same pre-existing isolated-storage failures unrelated to this change (same as on PR #32)
- [ ] After merge + deploy: re-submit the Pragmatic Engineer episode and confirm it completes with a partial transcript instead of failing.