### PR TITLE
Surface episode deck in the RSS feed

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -505,6 +505,7 @@ function toRfc822Date(isoDate: string): string {
  */
 interface EpisodeWithSummary extends EpisodeIndexEntry {
     summaryText?: string;
+    deck?: string;
 }
 
 /**
@@ -518,11 +519,18 @@ async function enrichWithSummaries(
 ): Promise<EpisodeWithSummary[]> {
     return Promise.all(
         episodes.map(async (ep) => {
-            const summaries = await listSummariesForEpisode(kv, ep.id);
+            // The deck lives only on the full Episode record, not the index
+            // entry, so fetch it alongside the summary. Mirrors how the home
+            // page hydrates decks per row (see GET / in this file).
+            const [summaries, fullEpisode] = await Promise.all([
+                listSummariesForEpisode(kv, ep.id),
+                getEpisode(kv, ep.id),
+            ]);
             const summary = summaries.find(s => s.templateId === defaultTemplate) || summaries[0];
             return {
                 ...ep,
                 summaryText: summary?.text,
+                deck: fullEpisode?.deck,
             };
         })
     );
@@ -575,18 +583,26 @@ function buildRssFeed(
             ? ep.tags.map((tag) => `        <category>${escapeXml(tag)}</category>`).join("\n")
             : "";
         
-        // Build content with podcast info header and summary (converted to HTML)
+        // Build content with the deck (when present), podcast info header, and
+        // summary (converted to HTML). The deck sits above the summary as a
+        // standfirst, mirroring the web ordering.
         const podcastInfo = `${ep.podcastName} • ${formatDuration(ep.episodeDuration)}`;
+        const deckHtml = ep.deck ? `<p>${escapeHtml(ep.deck)}</p>` : "";
         const summaryHtml = ep.summaryText
-            ? `<p><strong>${escapeHtml(podcastInfo)}</strong></p>${renderMarkdown(ep.summaryText)}`
-            : `<p>${escapeHtml(podcastInfo)}</p>`;
+            ? `${deckHtml}<p><strong>${escapeHtml(podcastInfo)}</strong></p>${renderMarkdown(ep.summaryText)}`
+            : `${deckHtml}<p>${escapeHtml(podcastInfo)}</p>`;
 
         // Use content:encoded for full content (prevents RSS readers from
         // fetching the page and showing the transcript instead of the summary).
-        // description gets a plain-text excerpt for readers that don't support content:encoded.
-        const plainExcerpt = ep.summaryText
-            ? ep.summaryText.replace(/[#*_`\[\]]/g, "").substring(0, 500)
-            : podcastInfo;
+        // description gets a plain-text blurb for readers that don't support
+        // content:encoded — prefer the deck (already a clean 1-2 sentence
+        // summary), falling back to a stripped summary excerpt for pre-deck
+        // episodes.
+        const plainExcerpt = ep.deck
+            ? ep.deck
+            : ep.summaryText
+                ? ep.summaryText.replace(/[#*_`\[\]]/g, "").substring(0, 500)
+                : podcastInfo;
 
         return `    <item>
       <title>${escapeXml(`${ep.podcastName} - ${ep.episodeTitle}`)}</title>

--- a/test/feed-deck.test.ts
+++ b/test/feed-deck.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for surfacing the episode deck in the RSS feed (issue #43).
+ *
+ * All three feed variants (/feed, /feed?tag=, /podcasts/:id/feed) funnel through
+ * the shared enrichWithSummaries + buildRssFeed path, so exercising the global
+ * /feed route covers the behavior for every variant.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, SELF } from "cloudflare:test";
+import { saveEpisode, saveSummary } from "../src/lib/kv";
+import type { Episode, Summary } from "../src/types";
+
+async function clearTestData() {
+    // "episodes:" catches the index key; "episode:" catches individual records.
+    const prefixes = ["episode:", "episodes:", "transcript:", "summary:"];
+    for (const prefix of prefixes) {
+        const keys = await env.TLDL_DATA.list({ prefix });
+        await Promise.all(keys.keys.map((k) => env.TLDL_DATA.delete(k.name)));
+    }
+}
+
+function sampleEpisode(overrides: Partial<Episode> = {}): Episode {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000);
+    return {
+        id: "111_222",
+        appleUrl: "https://podcasts.apple.com/us/podcast/test/id111?i=222",
+        podcastName: "Test Podcast",
+        episodeTitle: "Test Episode",
+        episodeDuration: 2700,
+        episodeDate: "2024-01-15",
+        audioUrl: "https://example.com/audio.mp3",
+        transcriptSource: "rss",
+        createdAt: now.toISOString(),
+        expiresAt: expiresAt.toISOString(),
+        ...overrides,
+    };
+}
+
+function sampleSummary(overrides: Partial<Summary> = {}): Summary {
+    return {
+        episodeId: "111_222",
+        templateId: "key-takeaways",
+        text: "# Key Takeaways\n\nSummarybody marker with details about the topic.",
+        model: "gpt-5.2",
+        createdAt: new Date().toISOString(),
+        ...overrides,
+    };
+}
+
+// Isolate the single feed <item> so assertions don't accidentally match the
+// channel-level <description>.
+function itemXml(feed: string): string {
+    const start = feed.indexOf("<item>");
+    return start === -1 ? "" : feed.slice(start);
+}
+
+describe("RSS feed deck (issue #43)", () => {
+    beforeEach(async () => {
+        await clearTestData();
+    });
+
+    it("uses the deck as <description> and includes it in <content:encoded> when present", async () => {
+        const deck = "Deckblurb marker summarizing the conversation in one line.";
+        await saveEpisode(env.TLDL_DATA, sampleEpisode({ deck }));
+        await saveSummary(env.TLDL_DATA, sampleSummary());
+
+        const res = await SELF.fetch("http://localhost/feed");
+        expect(res.status).toBe(200);
+
+        const item = itemXml(await res.text());
+
+        // The deck — a clean 1-2 sentence blurb — becomes the item description,
+        // improving readers that only render <description>.
+        expect(item).toContain(`<description>${deck}</description>`);
+
+        // content:encoded leads with the deck, then still carries the summary body.
+        expect(item).toContain(deck);
+        expect(item).toContain("Summarybody marker");
+    });
+
+    it("degrades gracefully when an episode has no deck", async () => {
+        // Pre-redesign episodes have no deck (Episode.deck is optional).
+        await saveEpisode(env.TLDL_DATA, sampleEpisode({ deck: undefined }));
+        await saveSummary(env.TLDL_DATA, sampleSummary());
+
+        const res = await SELF.fetch("http://localhost/feed");
+        expect(res.status).toBe(200);
+
+        const item = itemXml(await res.text());
+
+        // <description> falls back to the stripped summary excerpt (current behavior).
+        expect(item).toContain("Summarybody marker");
+        // No empty deck paragraph leaks into content:encoded.
+        expect(item).not.toContain("<p></p>");
+    });
+});


### PR DESCRIPTION
Closes #43.

Feed subscribers now get the same editorial **deck** that web and email readers already see.

## What changed
- **`enrichWithSummaries`** fetches the full `Episode` per feed item (in parallel with the summary lookup) to read its `deck` — the same per-item-fetch pattern the home page already uses to hydrate decks in its rows. No schema change, no backfill.
- **`buildRssFeed`** renders the deck as the `<description>` (falling back to the stripped summary excerpt when there's no deck) and as a `<p>` standfirst above the summary in `<content:encoded>`.

Covers all three feed variants (`/feed`, `/feed?tag=`, `/podcasts/:id/feed`) since they all funnel through `enrichWithSummaries` + `buildRssFeed`.

## Scope
Deck only. `pullQuote` is intentionally **not** surfaced in the feed (the issue's acceptance criteria mention it, but we scoped that out).

## Test plan
- New `test/feed-deck.test.ts` exercises the real `/feed` route through the workerd runtime:
  - deck present → appears in both `<description>` and `<content:encoded>`
  - no deck → degrades to the summary excerpt, no stray empty `<p></p>`
- Full suite green (494/494), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)