### PR TITLE
Add episode-summary model A/B harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ coverage/
 
 # Worktrees
 .worktrees/
+
+# Model A/B harness output (scripts/ab-summary.ts)
+scripts/ab-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ Clear all local state (KV + Durable Objects) and start fresh:
 rm -rf .wrangler/state && npx tsx scripts/seed-local-data.ts
 ```
 
+Compare summary models before adopting a new one (see [Model A/B harness](#model-ab-harness)):
+```bash
+npm run ab:summary                  # curated 6-episode sample, gpt-5.4 vs gpt-5.5
+npm run ab:summary -- --random 8    # 8 random prod transcripts
+npm run ab:summary -- --help
+```
+
 ## Architecture Overview
 
 TLDL is a Cloudflare Workers application that generates AI summaries of podcast episodes. It's an **admin-curated archive** — only admins can submit episodes and manage podcasts. Visitors browse, read, subscribe via RSS, or request a podcast to be added.
@@ -191,6 +198,22 @@ Defined in `src/lib/constants.ts`:
 - `key-takeaways` — Professional/craft podcasts (default)
 - `narrative-summary` — Story-driven content
 - `eli5` — Technical topics explained simply
+
+The summary model is a single constant: `MODEL` in `src/services/summarization.ts` (also `editorial-meta.ts` for deck/pull quote, `tag-generation.ts` for tags). Currently `gpt-5.4` via the OpenAI Responses API. Swapping it is a one-line change per service.
+
+### Model A/B harness
+
+`scripts/ab-summary.ts` (run via `npm run ab:summary`) compares summary models head-to-head before you change that constant. It runs the **exact production prompt** over **real prod transcripts** (pulled from KV) through two or more models with fresh, cache-bypassed calls, and writes a side-by-side markdown report with per-run **token usage, word count, latency, and cost**. Output lands in `scripts/ab-results/` (gitignored). It's not wired into the Worker — it's a standalone decision tool.
+
+```bash
+npm run ab:summary                              # curated 6-episode sample, gpt-5.4 vs gpt-5.5
+npm run ab:summary -- --random 8                # 8 random prod transcripts
+npm run ab:summary -- <episodeId> <episodeId>   # specific episodes
+npm run ab:summary -- --models gpt-5.4,gpt-5.6  # compare against a newly released model
+npm run ab:summary -- --template narrative-summary
+```
+
+When a new model ships, add its per-1M input/output price to the `PRICING` map at the top of the script (unknown models still run, cost just shows `n/a`), then run it against the curated sample. Watch the **Words** column — the `key-takeaways` template asks for 400–600 words, and length drift is a real differentiator (e.g. the 2026-06-21 run found gpt-5.5 cost ~2.3× more, ran ~2× slower, and overshot the word budget for marginal quality gains, so we stayed on gpt-5.4).
 
 ### Episode Tags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^25.6.0",
         "@vitest/runner": "^4.1.5",
         "@vitest/snapshot": "^4.1.5",
+        "tsx": "^4.22.4",
         "typescript": "^5.7.0",
         "vitest": "^4.1.5",
         "wrangler": "^4.63.0"
@@ -2514,6 +2515,509 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "deploy": "wrangler deploy --env=\"\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "ab:summary": "tsx scripts/ab-summary.ts"
   },
   "dependencies": {
     "fast-xml-parser": "^5.3.3",
@@ -21,6 +22,7 @@
     "@types/node": "^25.6.0",
     "@vitest/runner": "^4.1.5",
     "@vitest/snapshot": "^4.1.5",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.0",
     "vitest": "^4.1.5",
     "wrangler": "^4.63.0"

--- a/scripts/ab-summary.ts
+++ b/scripts/ab-summary.ts
@@ -1,0 +1,268 @@
+/**
+ * Episode-summary model A/B harness.
+ *
+ * Runs the EXACT production summary prompt over real prod transcripts through
+ * two or more models (OpenAI Responses API) and writes a side-by-side markdown
+ * report with per-run token usage, word count, latency, and cost. Use it to
+ * decide whether to adopt a newly released model for episode summaries before
+ * touching `src/services/summarization.ts`.
+ *
+ * Not wired into the Worker. Cache-bypassed (fresh API calls every run).
+ *
+ *   npm run ab:summary                       # curated 6-episode sample, gpt-5.4 vs gpt-5.5
+ *   npm run ab:summary -- --random 8         # 8 random transcripts from prod KV
+ *   npm run ab:summary -- <id> <id> ...      # specific episode IDs
+ *   npm run ab:summary -- --models gpt-5.4,gpt-5.5,gpt-5.6
+ *   npm run ab:summary -- --template narrative-summary
+ *   npm run ab:summary -- --help
+ *
+ * Adding a new model: just pass it via --models. If its price isn't in PRICING
+ * below, cost shows as n/a (add the row to get $ numbers).
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { getTemplate, isValidTemplateId } from "../src/lib/constants";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..");
+
+const KV_NAMESPACE = "ee123158d5d54359b4257f8a1b678adf"; // TLDL_DATA (prod), see wrangler.toml
+const RESPONSES_URL = "https://api.openai.com/v1/responses";
+
+// USD per 1M tokens (input / output). Add a row when a new model ships so the
+// report can show cost; unknown models still run (cost = n/a).
+const PRICING: Record<string, { in: number; out: number }> = {
+    "gpt-5.4": { in: 2.5, out: 15 },
+    "gpt-5.5": { in: 5.0, out: 30 },
+    "gpt-5.5-pro": { in: 30, out: 180 },
+};
+
+const DEFAULT_MODELS = ["gpt-5.4", "gpt-5.5"];
+const DEFAULT_TEMPLATE = "key-takeaways"; // prod default (wrangler.toml DEFAULT_TEMPLATE)
+
+// Curated default sample: 6 episodes across 6 distinct shows, mixed lengths.
+const DEFAULT_EPISODES = [
+    "1809663079_1000773109920", // How I AI
+    "1548604447_1000773386224", // Ezra Klein
+    "1627920305_1000771544935", // Lenny's
+    "1769051199_1000760299204", // Pragmatic Engineer
+    "1737704130_1000752597036", // Supra Insider
+    "1190000968_1000761835607", // Eat Sleep Work Repeat
+];
+
+interface Usage {
+    input_tokens: number;
+    output_tokens: number;
+}
+
+interface Args {
+    episodes: string[];
+    models: string[];
+    template: string;
+    random: number | null;
+    out: string | null;
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = { episodes: [], models: DEFAULT_MODELS, template: DEFAULT_TEMPLATE, random: null, out: null };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--help" || a === "-h") {
+            printHelp();
+            process.exit(0);
+        } else if (a === "--models") {
+            args.models = argv[++i].split(",").map((s) => s.trim()).filter(Boolean);
+        } else if (a === "--template") {
+            args.template = argv[++i];
+        } else if (a === "--random") {
+            args.random = parseInt(argv[++i], 10);
+        } else if (a === "--out") {
+            args.out = argv[++i];
+        } else if (a.startsWith("--")) {
+            throw new Error(`Unknown flag: ${a} (try --help)`);
+        } else {
+            args.episodes.push(a);
+        }
+    }
+    return args;
+}
+
+function printHelp() {
+    console.log(
+        `episode-summary model A/B harness\n\n` +
+            `Usage: npm run ab:summary -- [options] [episodeId ...]\n\n` +
+            `Options:\n` +
+            `  --random N            Sample N random transcripts from prod KV\n` +
+            `  --models a,b,c        Models to compare (default: ${DEFAULT_MODELS.join(", ")})\n` +
+            `  --template ID         Summary template: key-takeaways | narrative-summary | eli5\n` +
+            `  --out PATH            Output markdown path (default: scripts/ab-results/<ts>.md)\n` +
+            `  --help                This help\n\n` +
+            `With no episode IDs and no --random, runs a curated 6-episode sample.`
+    );
+}
+
+function readApiKey(): string {
+    const vars = readFileSync(join(REPO_ROOT, ".dev.vars"), "utf8");
+    const match = vars.match(/^OPENAI_API_KEY\s*=\s*"?([^"\n]+)"?/m);
+    if (!match) throw new Error("OPENAI_API_KEY not found in .dev.vars");
+    return match[1].trim();
+}
+
+function kvGet(key: string): string | null {
+    try {
+        return execFileSync(
+            "npx",
+            ["wrangler", "kv", "key", "get", key, "--namespace-id", KV_NAMESPACE, "--remote"],
+            { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"], cwd: REPO_ROOT }
+        );
+    } catch {
+        return null;
+    }
+}
+
+function kvListTranscripts(): string[] {
+    const raw = execFileSync(
+        "npx",
+        ["wrangler", "kv", "key", "list", "--namespace-id", KV_NAMESPACE, "--remote"],
+        { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"], cwd: REPO_ROOT }
+    );
+    return (JSON.parse(raw) as { name: string }[])
+        .map((k) => k.name)
+        .filter((n) => n.startsWith("transcript:"))
+        .map((n) => n.slice("transcript:".length));
+}
+
+function sample<T>(arr: T[], n: number): T[] {
+    const copy = [...arr];
+    const out: T[] = [];
+    while (out.length < n && copy.length) {
+        out.push(copy.splice(Math.floor(Math.random() * copy.length), 1)[0]);
+    }
+    return out;
+}
+
+function extractText(data: any): string {
+    const content = data?.output?.find((o: any) => o.type === "message")?.content?.[0];
+    return content?.text ?? "";
+}
+
+function costStr(usage: Usage, model: string): string {
+    const p = PRICING[model];
+    if (!p) return "n/a";
+    return "$" + ((usage.input_tokens / 1e6) * p.in + (usage.output_tokens / 1e6) * p.out).toFixed(4);
+}
+
+function wordCount(text: string): number {
+    return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+async function runModel(
+    model: string,
+    instructions: string,
+    transcript: string,
+    apiKey: string
+): Promise<{ text: string; usage: Usage; ms: number }> {
+    const started = Date.now();
+    const res = await fetch(RESPONSES_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ model, instructions, input: transcript }),
+    });
+    const ms = Date.now() - started;
+    if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`${model} HTTP ${res.status}: ${body.slice(0, 300)}`);
+    }
+    const data = (await res.json()) as any;
+    return { text: extractText(data), usage: data.usage ?? { input_tokens: 0, output_tokens: 0 }, ms };
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (!isValidTemplateId(args.template)) {
+        throw new Error(`Invalid template "${args.template}" (key-takeaways | narrative-summary | eli5)`);
+    }
+    const instructions = getTemplate(args.template)!.prompt;
+    const apiKey = readApiKey();
+
+    let episodeIds = args.episodes;
+    if (args.random) {
+        console.error(`Sampling ${args.random} random transcripts from prod KV...`);
+        episodeIds = sample(kvListTranscripts(), args.random);
+    } else if (episodeIds.length === 0) {
+        episodeIds = DEFAULT_EPISODES;
+    }
+
+    console.error(`Models: ${args.models.join(", ")} · template: ${args.template} · episodes: ${episodeIds.length}\n`);
+
+    const sections: string[] = [];
+    const rows: string[] = [];
+
+    for (const id of episodeIds) {
+        console.error(`=== ${id} ===`);
+        const rawT = kvGet(`transcript:${id}`);
+        if (!rawT) {
+            console.error("  no transcript, skipping");
+            continue;
+        }
+        const transcript = (JSON.parse(rawT) as { text: string }).text;
+        const rawE = kvGet(`episode:${id}`);
+        const ep = rawE ? (JSON.parse(rawE) as { episodeTitle: string; podcastName: string }) : null;
+        const title = ep ? `${ep.podcastName} — ${ep.episodeTitle}` : id;
+        const approxIn = Math.round(transcript.length / 4);
+        console.error(`  ${title}\n  transcript ~${approxIn.toLocaleString()} tokens`);
+
+        sections.push(`## ${title}\n\n*Transcript ~${approxIn.toLocaleString()} tokens · template \`${args.template}\`*\n`);
+
+        for (const model of args.models) {
+            process.stderr.write(`  running ${model}... `);
+            let r: { text: string; usage: Usage; ms: number };
+            try {
+                r = await runModel(model, instructions, transcript, apiKey);
+            } catch (e) {
+                console.error(`FAILED: ${(e as Error).message}`);
+                sections.push(`### ${model}\n\n_Failed: ${(e as Error).message}_\n`);
+                continue;
+            }
+            const words = wordCount(r.text);
+            console.error(`${(r.ms / 1000).toFixed(1)}s · ${words} words · ${r.usage.output_tokens} out · ${costStr(r.usage, model)}`);
+            rows.push(
+                `| ${title.slice(0, 38)} | ${model} | ${r.usage.input_tokens} | ${r.usage.output_tokens} | ${words} | ${(r.ms / 1000).toFixed(1)}s | ${costStr(r.usage, model)} |`
+            );
+            sections.push(
+                `### ${model}\n\n` +
+                    `<sub>${r.usage.input_tokens} in / ${r.usage.output_tokens} out · ${words} words · ${(r.ms / 1000).toFixed(1)}s · ${costStr(r.usage, model)}</sub>\n\n` +
+                    r.text +
+                    "\n"
+            );
+        }
+        sections.push("---\n");
+    }
+
+    const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+    const outDir = join(REPO_ROOT, "scripts", "ab-results");
+    mkdirSync(outDir, { recursive: true });
+    const out = args.out ?? join(outDir, `summary-ab-${stamp}.md`);
+
+    const header =
+        `# tldl episode-summary A/B\n\n` +
+        `Models: ${args.models.join(", ")} · template \`${args.template}\` · ${episodeIds.length} episodes · ${stamp}\n` +
+        `Generated by \`scripts/ab-summary.ts\` — production prompt, real prod transcripts, fresh (cache-bypassed) calls.\n\n` +
+        `## Cost · words · latency per run\n\n` +
+        `| Episode | Model | In | Out | Words | Latency | Cost |\n` +
+        `|---|---|--:|--:|--:|--:|--:|\n` +
+        rows.join("\n") +
+        `\n\n*The \`key-takeaways\` template asks for 400–600 words — watch the Words column for length drift.*\n\n---\n`;
+
+    writeFileSync(out, header + sections.join("\n"));
+    console.error(`\nWrote ${out}`);
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
Adds `scripts/ab-summary.ts` (`npm run ab:summary`) — a standalone tool to compare summary models head-to-head before changing the `MODEL` constant in `src/services/summarization.ts`.

It runs the **exact production prompt** over **real prod transcripts** (pulled from KV) through two or more models with fresh, cache-bypassed calls, and writes a side-by-side markdown report with per-run **token usage, word count, latency, and cost** to `scripts/ab-results/` (gitignored).

## Usage
```bash
npm run ab:summary                              # curated 6-episode sample, gpt-5.4 vs gpt-5.5
npm run ab:summary -- --random 8                # random prod transcripts
npm run ab:summary -- --models gpt-5.4,gpt-5.6  # compare a newly released model
npm run ab:summary -- --help
```

When a new model ships: add its per-1M price to the `PRICING` map, run it against the curated sample, watch the Words column (the `key-takeaways` template targets 400–600 words; length drift is a real differentiator).

## Changes
- `scripts/ab-summary.ts` — the harness
- `package.json` — `ab:summary` script + `tsx` devDependency
- `.gitignore` — `scripts/ab-results/`
- `CLAUDE.md` — Model A/B harness section + dev-command reference

## Not a runtime change
Standalone tool, not wired into the Worker. Summaries stay on `gpt-5.4` — the 2026-06-21 run found gpt-5.5 cost ~2.3× more, ran ~2× slower, and overshot the word budget for marginal quality gains. **No deploy needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)